### PR TITLE
ログイン・ログアウト後のページ遷移変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,7 +16,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.save
       @profile.save
       sign_in(:user, @user)
-      redirect_to root_path
+      redirect_to user_path(@user)
     else
       render action: :new
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,15 @@
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  # ログイン後にマイページに遷移する
+  def after_sign_in_path_for(resource)
+    user_path(resource)
+  end
+
+  # ログアウト後にログイン画面に遷移する
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, except: :index
 
   def index
     @users = User.includes(:profile)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,15 @@
 <div class="header">
-  <a href="/" class="header-left">ロゴ</a>
+  <% if user_signed_in? %>
+    <%= link_to "ロゴ", user_path(current_user), class:"header-left" %>
+  <% else %>
+    <%= link_to "ロゴ", users_path, class:"header-left" %>
+  <% end %>
 
   <div class="header-right">
     <ul class="header-menu">
       <% if user_signed_in? %>
-        <li><a href="/communities">コミュニティ</a></li>
+        <li><%= link_to "ユーザー一覧", users_path %></li>
+        <li><a href="/communities">コミュニティ一覧</a></li>
         <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
         <li><%= link_to "#{current_user.name}", user_path(current_user) %></li>
       <% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -30,7 +30,7 @@
           <%= f.text_area :text, class:"task-input text" %>
         </div>
         
-        <%= f.submit "投稿", class:"submit-btn" %>
+        <%= f.submit "更新", class:"submit-btn" %>
 
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
-  root to: 'users#index'
+  # root to: 'users#index'
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
   }
 
   resources :users, only: [:index, :show] do


### PR DESCRIPTION
Closes #22 

## What
・全ページログイン必須に設定
・deviseのsessionコントローラーでログイン・ログアウト後の遷移を設定
・registrationコントローラーでサインアップ後にマイページ遷移を設定
・ヘッダーからユーザー一覧へ遷移できるよう追加
## What
・サインアップ後にスムーズに始められるようにするため