### PR TITLE
DM投稿後の遷移不具合を解消

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,16 +1,15 @@
 class MessagesController < ApplicationController
   def create
     @message = Message.new(message_params)
-    binding.pry
     if @message.save
-      redirect_to room_path(params[:room_id])
+      redirect_to room_path(params[:message][:room_id])
     else
-      redirect_to room_path(params[:room_id])
+      redirect_to room_path(params[:message][:room_id])
     end
   end
 
   private
   def message_params
-    params.require(:message).permit(:text).merge(room_id: params[:room_id], user_id: current_user.id)
+    params.require(:message).permit(:text, :room_id).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,27 +1,23 @@
 class RoomsController < ApplicationController
   def show
-    # 相手ユーザーを取得
-    @user = User.find(params[:id])
+    @room = Room.find(params[:id])
+    # DM相手のデータを取得
+    current_user_room = @room.user_rooms.where.not(user_id: current_user.id).take
+    user_id = current_user_room.user_id
+    @user = User.find(user_id)
 
-    # user_roomから自分が含まれるidを取得
-    room_ids = current_user.user_rooms.pluck(:room_id)
-    # 取得したuser_roomのうち、自分と相手のペアを探す
-    target_user_room = UserRoom.find_by(room_id: room_ids, user_id: @user.id)
-    
-    if target_user_room.present?
-      # 自分と相手のペアがあれば、そこがDMをするroom
-      @room = target_user_room.room
-    else
-      # 無ければ、roomを作成する、そこがDMをするroom
-      @room = Room.create
-      # user_roomに「自分id - 作成したroom_id」「相手id - 作成したroom_id」を保存する
-      UserRoom.create(user_id: current_user.id, room_id: @room.id)
-      UserRoom.create(user_id: @user.id, room_id: @room.id)
-    end
-
-    # roomで表示するmessage
     @messages = @room.messages.includes(:user)
-    # 投稿用にmesssageインスタンス作成
     @message = Message.new
   end
+
+  def create
+    binding.pry
+    if @room = Room.create
+      # user_roomに「自分id - 作成したroom_id」「相手id - 作成したroom_id」を保存する
+      UserRoom.create(user_id: current_user.id, room_id: @room.id)
+      UserRoom.create(user_id: params[:format], room_id: @room.id)
+      redirect_to room_path(@room.id)
+    end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,18 @@ class UsersController < ApplicationController
     @tasks = Task.where(user_id: @user.id).order("created_at DESC")
     @following_users = @user.followings
     @follower_users = @user.followers
+
+
+    # DM用するボタンのためのデータ取得
+    # user_roomから自分が含まれるidを取得
+    room_ids = current_user.user_rooms.pluck(:room_id)
+    # 取得したuser_roomのうち、自分と相手のペアを探す
+    @target_user_room = UserRoom.find_by(room_id: room_ids, user_id: @user.id)    
+    # 特定したuser_roomからroom_idを取得する
+    if @target_user_room.present?
+      @room = @target_user_room.room
+    end
+
   end
 
   # フォロー数

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -21,8 +21,9 @@
           </div>     
         <% end %>
       </div>
-      <%= form_with model: [@room, @message], local: true, class:"message-form-area" do |f| %>
+      <%= form_with model: @message, local: true, class:"message-form-area" do |f| %>
         <%= f.text_field :text, class:"message-form" %>
+        <%= f.hidden_field :room_id, value: @room.id %>
         <%= f.submit "投稿", class:"message-submit"%>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,11 @@
         <li>フォロー <%= link_to "#{@following_users.count}", follows_user_path(@user) %></li>
         <li>フォロワー <%= link_to "#{@follower_users.count}", followers_user_path(@user) %></li>
         <% if current_user != @user %>
-          <li><%= link_to "DMする", room_path(@user) %></li>
+          <% if @room.present? %>
+            <li><%= link_to "DMする", room_path(@room.id) %> </li>
+          <% elsif %>
+            <li><%= link_to "DMする", rooms_path(@user.id), method: :post %> </li>
+          <% end %>
         <% end %>
         <li>参加コミュニティ</li>
         <li>ユーザーを探す</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :rooms, only: :show do
-    resources :messages, only: :create
-  end
-
+  resources :rooms, only: [:create, :show]
+  resources :messages, only: :create
+  
 end


### PR DESCRIPTION
Closes #26 
## What
・roomとmessageでルーティングを独立
・ユーザー詳細ページに遷移時にDM履歴があるかどうか判定
・履歴の有無でDMボタンのアクションを分岐
## Why
・不具合を解消するため