### PR TITLE
日本時間で表示

### DIFF
--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -16,7 +16,7 @@
               <%= message.text %>
             </span>
             <span class="chat-text">
-              <%= message.created_at %>
+              <%= l message.created_at %>
             </span>            
           </div>     
         <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module TaskShare
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"


### PR DESCRIPTION
Closes #15 
## What
・読み取りのタイムゾーンをTokyoに変更
・`l`メソッドで表示フォーマットを設定
## Why
・現状のUTCから変更するため

## その他
・インフラへの影響を考慮し、今回はシンプルな方法で実装