### PR TITLE
ルートパスにログイン画面を設定

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,7 +2,7 @@
   <% if user_signed_in? %>
     <%= link_to "ロゴ", user_path(current_user), class:"header-left" %>
   <% else %>
-    <%= link_to "ロゴ", users_path, class:"header-left" %>
+    <%= link_to "ロゴ", new_user_session_path, class:"header-left" %>
   <% end %>
 
   <div class="header-right">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  # root to: 'users#index'
+  devise_scope :users do
+    get '/', to: 'users/sessions#new'
+  end
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions'


### PR DESCRIPTION
Closes #27 
## What
・ルートページはログイン画面へ遷移させる
・ログアウト時のロゴの遷移先も、ユーザー一覧からログイン画面へ変更
## What
・ルートが設定されていない状態を解消するため