### PR TITLE
コミュニティ内のtask表示不具合の解消

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -33,7 +33,8 @@ class CommunitiesController < ApplicationController
   end
 
   def show
-    @tasks = Task.includes(:user)
+    task_user_ids = @community.user_communities.pluck(:user_id)
+    @tasks = Task.where(user_id: task_user_ids).order("created_at DESC")
   end
   
   def join

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -49,7 +49,7 @@ class TasksController < ApplicationController
   def done
     set_task
     @task.update(state: 1)
-    redirect_to user_path(current_user)
+    redirect_to request.referer
   end
 
   private


### PR DESCRIPTION
Closes #34 
## What
・コミュニティ詳細では、参加者のみのtaskを表示させるように修正
## Why
・コミュニティでは参加者のデータにフォーカスできるようにするため