### PR TITLE
ナビゲーション下線のスタイリング調整

### DIFF
--- a/app/assets/stylesheets/communities.scss
+++ b/app/assets/stylesheets/communities.scss
@@ -142,7 +142,7 @@
 .community-navigation {
   color: $main-text-color;
   &:hover {
-    text-decoration: underline;
+    border-bottom: 2px solid lightgray;
   }
 }
 .task {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -217,6 +217,9 @@
 .search-navigation {
   color: $main-text-color;
   margin-right: 8px;
+    &:hover {
+    border-bottom: 2px solid lightgray;
+    }
 }
 .user-card {
   width: 100%;

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -29,7 +29,7 @@
     <div class="main-menu">
       <%= link_to "みんなのタスク", community_path(@community), class:"community-navigation" %>
       <%= link_to "チャット", community_chats_path(@community), class:"community-navigation" %>
-      <%= link_to "質問", community_questions_path(@community), class:"community-navigation" %>
+      <%= link_to "質問", community_questions_path(@community), class:"community-navigation question" %>
     </div>
   </div>
   <div class="question-area">


### PR DESCRIPTION
Closes #49 
## What
・ユーザー/コミュニティ一覧、コミュニティ詳細のナビゲーションのunderlineを削除
・ホバー時にborder-bottomにlightgrayで表示(カレントと同じサイズで)
## What
・ページ見やすさ向上のため