### PR TITLE
表示されるタスクを未完了のものに限定する

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -150,3 +150,12 @@
   margin-left: 15px;
   text-align: center;
 }
+
+/* 完了タスク一覧 */
+.task-index-user-name {
+  color: $main-text-color;
+  margin-right: 8px;
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -6,8 +6,8 @@ class ChatsController < ApplicationController
   def index
     @chat = Chat.new
     @joined_users = @community.joined_users
-    joined_user_ids = @joined_users.pluck(:id)
-    @tasks = Task.where(user_id: joined_user_ids).order("created_at DESC")
+    # タスク総数を取得 → ビューで完了未完了を分岐
+    @tasks = Task.user_is(@joined_users.pluck(:id)).order("created_at DESC")
     @questions = Question.where(community_id: @community.id)
   end
 
@@ -17,8 +17,8 @@ class ChatsController < ApplicationController
       redirect_to community_chats_path(@community)
     else
       @joined_users = @community.joined_users
-      joined_user_ids = @joined_users.pluck(:id)
-      @tasks = Task.where(user_id: joined_user_ids).order("created_at DESC")
+      # タスク総数を取得 → ビューで完了未完了を分岐
+      @tasks = Task.user_is(@joined_users.pluck(:id)).order("created_at DESC")
       @questions = Question.where(community_id: @community.id)
       render :index
     end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -34,9 +34,12 @@ class CommunitiesController < ApplicationController
   end
 
   def show
+    # 参加ユーザー
     @joined_users = @community.joined_users
-    joined_user_ids = @joined_users.pluck(:id)
-    @tasks = Task.where(user_id: joined_user_ids).order("created_at DESC")
+    # 参加ユーザーのタスク(サイドバー)
+    @tasks = Task.user_is(@joined_users.pluck(:id))
+    # うち未完了のタスク(一覧表示)
+    @remain_tasks = @tasks.not_completed.order("created_at DESC")
     @questions = Question.where(community_id: @community.id)
   end
   

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,8 +11,7 @@ class QuestionsController < ApplicationController
     @questions = @community.questions.includes(:user).order("created_at DESC")
     # サイドバー用データ取得
     @joined_users = @community.joined_users
-    joined_user_ids = @joined_users.pluck(:id)
-    @tasks = Task.where(user_id: joined_user_ids).order("created_at DESC")
+    @tasks = Task.user_is(@joined_users.pluck(:id))
   end
 
   def new
@@ -31,8 +30,7 @@ class QuestionsController < ApplicationController
   def show
     # サイドバー用データ取得
     @joined_users = @community.joined_users
-    joined_user_ids = @joined_users.pluck(:id)
-    @tasks = Task.where(user_id: joined_user_ids).order("created_at DESC")
+    @tasks = Task.user_is(@joined_users.pluck(:id))
     @questions = @community.questions
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,10 @@ class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :move_to_index
 
+  def index
+    @tasks = Task.user_is(params[:user_id]).completed
+  end
+
   def new
     set_user
     set_profile

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   def show
     set_user
-    @tasks = Task.where(user_id: @user.id).order("created_at DESC")
+    @tasks = Task.user_is(@user.id).not_completed.order("created_at DESC")
     @following_users = @user.followings
     @follower_users = @user.followers
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,12 @@ class Task < ApplicationRecord
   has_many :likes
 
   validates :title, presence: true
+
+  # 特定のユーザーのタスクを取得
+  scope :user_is, -> (user_id) { where(user_id: user_id) if user_id.present? }
+
+  # 未完了のタスクを取得
+  scope :not_completed, -> { where(state: false) }
+  # 完了したタスクを取得
+  scope :completed, -> { where(state: true) }
 end

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -33,7 +33,7 @@
     </div>
   </div>
   <div class="posts">
-    <% @tasks.each do |task| %>
+    <% @remain_tasks.each do |task| %>
       <span id="task_<%= task.id %>">
         <%= render partial: "shared/tasks", locals: { task: task } %>
       </span>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -4,11 +4,11 @@
   <div class="task-post-form">
     <%= form_with model: [@user, @task], local: true do |f|%>
     <%= render 'shared/error_messages', model: f.object %>
-      <div class="task">
+      <div class="task-form">
         <%= f.label "タスク", class:"task-label"%>
         <%= f.text_field :title, class:"task-input" %>
       </div>
-      <div class="task">
+      <div class="task-form">
         <%= f.label "内容", class:"task-label"%>
         <%= f.text_area :text, class:"task-input text" %>
       </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,25 @@
+  <div class="menu-bar">
+
+  </div>
+    
+  <div class="main">
+    <div class="main-heading">
+      <%= link_to @user.name, user_path(@user), class:"task-index-user-name" %>の完了タスク
+    </div>
+    <div class="posts">
+      <% @tasks.each do |task| %>
+        <div id="task_<%= task.id %>">
+          <%= render partial: "shared/tasks", locals: { task: task} %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  
+  <div class="right-bar">
+    <div class="right-bar-box">
+    </div>
+    <div class="right-bar-box">
+    </div>
+  </div>
+  
+</div>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -22,7 +22,7 @@
         フォロワー <%= link_to "#{@follower_users.count}", followers_user_path(@user), class:"follower-count" %>
       </div>
       <div class="completed-task">
-        タスク数 <%= @user.tasks.count %>
+        完了タスク数 <%= link_to @user.tasks.where(state: true).count, user_tasks_path(@user.id) %>
       </div>
       <div class="direct-message">
         <% if current_user != @user %>


### PR DESCRIPTION
Closes #44 
## What
・タスク取得のスコープを指定
・usersコントローラーで未完了のタスクを取得
・マイページのメニューから、完了タスク一覧ページへ遷移
## Why
・マイページのデータ量が増え続けていくのを防ぐため