### PR TITLE
質問作成・編集のビュー崩れを修正

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -20,6 +20,47 @@
   color: lightcoral;
 }
 
+
+/* 質問作成ページ */
+.question-post-form {
+  background-color: $card-back-color;
+  width: 80%;
+  margin: 0 auto;
+  padding: 20px 20px 50px;
+  border-radius: 5px;
+  .question-form-item {
+    margin-top: 25px;
+    display: flex;
+  }
+  .question-label {
+    display: block;
+    min-width: 100px;
+  }
+  .question-input {
+    background-color: $base-color;
+    width: 80%;
+    padding: 10px 12px 8px;
+    outline: none;
+    font-size: 15px;
+    border: none;
+  }
+  .question-submit-btn {
+    background-color: $highlight;
+    color: $with-highlight;
+    display: block;
+    width: 100px;
+    margin: 30px auto 0;
+    padding: 5px 0;
+    border-radius: 10px;
+    border: none;
+    outline: none;
+    font-size: 20px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+
 .question-summary-card {
   width: 100%;
   margin: 10px auto 20px;

--- a/app/views/communities/new.html.erb
+++ b/app/views/communities/new.html.erb
@@ -16,10 +16,8 @@
       <div class="community">
         <%= f.label "説明", class:"community-label"%>
         <%= f.text_area :text, class:"community-input text" %>
-      </div>
-      
+      </div>      
       <%= f.submit "投稿", class:"community-submit-btn" %>
-
     <% end %>
   </div>
 </div>

--- a/app/views/questions/_question_post_form.html.erb
+++ b/app/views/questions/_question_post_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: [community, question], local: true do |f|%>
+  <%= render 'shared/error_messages', model: f.object %>
+  <div class="question-form-item">
+    <%= f.label "タイトル", class:"question-label"%>
+    <%= f.text_field :title, class:"question-input" %>
+  </div>
+  <div class="question-form-item">
+    <%= f.label "内容", class:"question-label"%>
+    <%= f.text_area :content, class:"question-input text" %>
+  </div>
+  
+  <div class="question-form-item">
+    <%= f.label "画像", class:"question-label"%>
+    <%= f.file_field :image %>
+  </div>
+
+  <%= f.submit "投稿", class:"question-submit-btn" %>
+<% end %>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,48 +1,16 @@
-<div class="wrapper">
-
-  <div class="menu-bar">
-    <div class="menu-bar-box">
-      <div class="menu-items">
-        <% if current_user.id == @community.user.id %>
-          <%= link_to "編集する", edit_community_path(@community), class:"community-edit-btn" %>
-        <% elsif current_user.already_joined?(@community) %>
-          <%= link_to "脱退する", exit_community_path(@community), method: :delete, class:"community-exit-btn" %>
-        <% else %>
-          <%= link_to "参加する", community_path(@community), method: :post, class:"community-join-btn" %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-    
-  <div class="main">
-    <div class="community-post-form">
-      <%= form_with model: [@community, @question], local: true do |f|%>
-        <%= render 'shared/error_messages', model: f.object %>
-        <div class="community">
-          <%= f.label "タイトル", class:"community-label"%>
-          <%= f.text_field :title, class:"community-input" %>
-        </div>
-        <div class="community">
-          <%= f.label "内容", class:"community-label"%>
-          <%= f.text_area :content, class:"community-input text" %>
-        </div>
-        
-        <div class="community">
-          <%= f.label "画像", class:"community-label"%>
-          <%= f.file_field :image %>
-        </div>
-
-        <%= f.submit "投稿", class:"submit-btn" %>
-      <% end %>
-      <%= link_to "削除する", community_question_path(@community, @question), method: :delete, class:"delete-btn" %>
-    </div>
-  </div>
+<div class="menu-bar">
+</div>
   
-  <div class="right-bar">
-    <div class="right-bar-box">
-    </div>
-    <div class="right-bar-box">
-    </div>
+<div class="main">
+  <div class="question-post-form">
+    <%= render partial: "question_post_form", locals: { community: @community, question: @question } %>
+    <%= link_to "削除する", community_question_path(@community, @question), method: :delete, class:"delete-btn" %>
   </div>
-  
+</div>
+
+<div class="right-bar">
+  <div class="right-bar-box">
+  </div>
+  <div class="right-bar-box">
+  </div>
 </div>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,47 +1,15 @@
-<div class="wrapper">
-
-  <div class="menu-bar">
-    <div class="menu-bar-box">
-      <div class="menu-items">
-        <% if current_user.id == @community.user.id %>
-          <%= link_to "編集する", edit_community_path(@community), class:"community-edit-btn" %>
-        <% elsif current_user.already_joined?(@community) %>
-          <%= link_to "脱退する", exit_community_path(@community), method: :delete, class:"community-exit-btn" %>
-        <% else %>
-          <%= link_to "参加する", community_path(@community), method: :post, class:"community-join-btn" %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-    
-  <div class="main">
-    <div class="community-post-form">
-      <%= form_with model: [@community, @question], local: true do |f|%>
-        <%= render 'shared/error_messages', model: f.object %>
-        <div class="community">
-          <%= f.label "タイトル", class:"community-label"%>
-          <%= f.text_field :title, class:"community-input" %>
-        </div>
-        <div class="community">
-          <%= f.label "内容", class:"community-label"%>
-          <%= f.text_area :content, class:"community-input text" %>
-        </div>
-        
-        <div class="community">
-          <%= f.label "画像", class:"community-label"%>
-          <%= f.file_field :image %>
-        </div>
-
-        <%= f.submit "投稿", class:"submit-btn" %>
-      <% end %>
-    </div>
-  </div>
+<div class="menu-bar">
+</div>
   
-  <div class="right-bar">
-    <div class="right-bar-box">
-    </div>
-    <div class="right-bar-box">
-    </div>
+<div class="main">
+  <div class="question-post-form">
+    <%= render partial: "question_post_form", locals: { community: @community, question: @question } %>
   </div>
-  
+</div>
+
+<div class="right-bar">
+  <div class="right-bar-box">
+  </div>
+  <div class="right-bar-box">
+  </div>
 </div>


### PR DESCRIPTION
Closes #61 
## What
・クラス名とcssの調整で質問作成・編集ページの修正
・部分テンプレートで作成・編集ページの共通化
## What
・ビューのレイアウト崩れを修正するため
・記述をまとめて後のメンテナンスをしやすくするため