### PR TITLE
タスク投稿をマイページで行えるようにする

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -3,26 +3,28 @@
 
 /* タスク投稿フォーム */
 .task-post-form {
-  width: 80%;
+  width: 100%;
   margin: 0 auto;
-  padding: 20px 20px 35px;
+  padding: 20px;
   border-radius: 5px;
   background-color: $card-back-color;
 
   .task-form {
-    margin-top: 25px;
-    display: flex;
+    // margin-bottom: 25px;
+    // display: flex;
     .field_with_errors {
       display: contents;
     }
     
     .task-label {
       display: block;
-      min-width: 70px;
+      margin-bottom: 5px;
+      font-weight: 500;
     }
     .task-input {
-      width: 80%;
+      width: 100%;
       padding: 10px 12px 8px;
+      margin-bottom: 8px;
       outline: none;
       font-size: 15px;
       border: none;
@@ -38,21 +40,26 @@
 
   .submit-btn {
     display: block;
-    width: 100px;
-    padding: 5px 0;
-    margin: 30px auto 0;
+    width: auto;
+    padding: 2px 8px;
+    margin: 0 0 0 auto;
     background-color: $highlight;
     color: $with-highlight;
     border: none;
     outline: none;
     font-size: 20px;
-    border-radius: 10px;
+    border-radius: 5px;
     &:hover {
       cursor: pointer;
     }
   }
 }
 
+/* フォームとタスクカード間の仕切り */
+.form-post-border {
+  border-top: 1px solid lightgray;
+  border: 10px 0;
+}
 
 /* タスクカード */
 .post-card {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -122,17 +122,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    border-radius: 10px;
-    
-    .task-post-btn {
-      background-color: $highlight;
-      color: #eff0f3;
-      font-size: 20px;
-      padding: 15px;        
-      width: 200px;
-      margin: 0 auto;
-      border-radius: 10px;
-    }
+    border-radius: 10px;    
   }
 }
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,13 @@ class UsersController < ApplicationController
     @users = User.search(@search_params).includes(:profile)
   end
 
-  def show
-    set_user
+  def show    
     @tasks = Task.user_is(@user.id).not_completed.order("created_at DESC")
     @following_users = @user.followings
     @follower_users = @user.followers
+    
+    # タスク投稿フォーム用
+    @task = Task.new
 
     # DM用するボタンのためのデータ取得
     # user_roomから自分が含まれるidを取得
@@ -23,13 +25,11 @@ class UsersController < ApplicationController
 
   # フォロー数
   def follows
-    set_user
     @following_users = @user.followings
   end
 
   # フォロワー数
   def followers
-    set_user
     @follower_users = @user.followers
   end
 

--- a/app/views/tasks/_task_form.html.erb
+++ b/app/views/tasks/_task_form.html.erb
@@ -1,0 +1,16 @@
+<div class="task-post-form">
+  <%= form_with model: [user, task], local: true do |f|%>
+    <%= render 'shared/error_messages', model: f.object %>
+    <div class="task-form">
+      <%= f.label "タスク", class:"task-label"%>
+      <%= f.text_field :title, placeholder: "なにする？", class:"task-input" %>
+    </div>
+    <div class="task-form">
+      <%= f.label "内容", class:"task-label"%>
+      <%= f.text_area :text, placeholder: "メモもしとく？", class:"task-input text" %>
+    </div>
+    
+    <%= f.submit "登録", class:"submit-btn" %>
+
+  <% end %>
+</div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,21 +1,8 @@
 <%= render partial: "users/sidebar", locals: { user: @user, profile: @profile, following_users: @following_users, follower_users: @follower_users, room: @room } %>
 
 <div class="main">
-  <div class="task-post-form">
-    <%= form_with model: [@user, @task], local: true do |f|%>
-    <%= render 'shared/error_messages', model: f.object %>
-      <div class="task-form">
-        <%= f.label "タスク", class:"task-label"%>
-        <%= f.text_field :title, class:"task-input" %>
-      </div>
-      <div class="task-form">
-        <%= f.label "内容", class:"task-label"%>
-        <%= f.text_area :text, class:"task-input text" %>
-      </div>
-      
-      <%= f.submit "更新", class:"submit-btn" %>
-
-    <% end %>
+  <div class="posts">
+    <%= render partial: "tasks/task_form", locals: { user: @user, task: @task } %>
   </div>
 </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,11 +2,12 @@
   
 <div class="main">
   <div class="main-heading">
-    <% if user_signed_in? && (current_user.id == @user.id) %>
-      <%= link_to "タスクを登録する", new_user_task_path(@user), class:"task-post-btn" %> 
-    <% end %>
   </div>
   <div class="posts">
+    <% if user_signed_in? && (current_user.id == @user.id) %>
+      <%= render partial: "tasks/task_form", locals: { user: @user, task: @task } %>
+    <% end %>
+    <hr class="form-post-border"></hr>
     <% @tasks.each do |task| %>
       <div id="task_<%= task.id %>">
         <%= render partial: "shared/tasks", locals: { task: task} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,8 +6,8 @@
   <div class="posts">
     <% if user_signed_in? && (current_user.id == @user.id) %>
       <%= render partial: "tasks/task_form", locals: { user: @user, task: @task } %>
+      <hr class="form-post-border"></hr>
     <% end %>
-    <hr class="form-post-border"></hr>
     <% @tasks.each do |task| %>
       <div id="task_<%= task.id %>">
         <%= render partial: "shared/tasks", locals: { task: task} %>


### PR DESCRIPTION
Closes #72 
## What
・tasks#newを通さずに、users#showに投稿フォームを移動
・投稿フォームをパーシャル化
・tasks#editのサイズを調整
## Why
・ページ遷移のストレスを無くすため
・非同期投稿の準備のため
