### PR TITLE
モデルテストの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
+  gem 'spring-commands-rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -324,6 +326,7 @@ DEPENDENCIES
   sass-rails (~> 5)
   selenium-webdriver
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -15,10 +15,14 @@ class Community < ApplicationRecord
   scope :search, -> (search_params) do
     return if search_params.blank?
 
-    category_is(search_params[:category_id]).text_like(search_params[:text])
+    category_is(search_params[:category_id])
+    .text_like(search_params[:text])
+    .name_like(search_params[:text])
+    
   end
   scope :category_is, -> (category_id) { where(category_id: category_id) if category_id.present? }
-  scope :text_like, -> (text) { where("text LIKE ?", "%#{text}%") if text.present? }
+  scope :text_like, -> (text) { where("text LIKE ?", "%#{name}%") if text.present? }
+  scope :name_like, -> (text) { where("name LIKE ?", "%#{text}%") if text.present? }
 
   def joined_users
     user_ids = user_communities.pluck(:user_id)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -17,12 +17,10 @@ class Community < ApplicationRecord
 
     category_is(search_params[:category_id])
     .text_like(search_params[:text])
-    .name_like(search_params[:text])
     
   end
   scope :category_is, -> (category_id) { where(category_id: category_id) if category_id.present? }
-  scope :text_like, -> (text) { where("text LIKE ?", "%#{name}%") if text.present? }
-  scope :name_like, -> (text) { where("name LIKE ?", "%#{text}%") if text.present? }
+  scope :text_like, -> (text) { where("text LIKE ?", "%#{text}%").or(where("name LIKE ?", "%#{text}%")) if text.present? }
 
   def joined_users
     user_ids = user_communities.pluck(:user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,32 +32,32 @@ class User < ApplicationRecord
   has_many :passive_relationships, class_name: "Relationship", foreign_key: :follower_id, dependent: :destroy
   has_many :followers, through: :passive_relationships, source: :following
 
-  # フォロー済みかどうかの確認
+  # 引数のユーザが既にフォローしているかどうかの確認
   def follow?(user)
     passive_relationships.find_by(following_id: user.id).present?
   end
 
-  # taskいいね済みかどうかの確認
+  # 引数のtaskにいいね済みかどうかの確認
   def already_liked?(task)
     likes.where(task_id: task.id).exists?
   end
 
-  # communityに参加済みかどうかの確認
+  # 引数のcommunityに参加済みかどうかの確認
   def already_joined?(community)
     user_communities.where(community_id: community.id).exists?
   end
 
-  # questionに「知りたい！」済みかどうかの確認
+  # 引数のquestionに「知りたい！」済みかどうかの確認
   def already_me_too?(question)
     me_toos.where(question_id: question.id).exists?
   end
 
-  # questionに「役に立った！」済みかどうかの確認
+  # 引数のquestionに「役に立った！」済みかどうかの確認
   def already_good?(question)
     goods.where(question_id: question.id).exists?
   end
 
-  # 検索
+  # ユーザ検索
   scope :search, -> (search_params) do
     # search_paramsが無かったら実行しない
     return if search_params.blank?
@@ -69,6 +69,7 @@ class User < ApplicationRecord
     where(id: profiles.pluck(:user_id))
   end
 
+  # ゲストユーザログイン時に「ゲスト」を検索or作成
   def self.guest
     find_or_create_by!(email: "guest@guest.com") do |user|
       user.name = "ゲスト"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,11 +62,17 @@ class User < ApplicationRecord
     # search_paramsが無かったら実行しない
     return if search_params.blank?
 
-    # 検索条件に合うprofileを取得
-    profiles = Profile.occupation_is(search_params[:occupation_id]).text_like(search_params[:text])
-
-    # 取得したprofileのuser_idからuserを検索
-    where(id: profiles.pluck(:user_id))
+    # userのnameが一致したuser
+    users_name_match = User.where("name LIKE ?", "%#{search_params[:text]}%")    
+    # profileのtextが一致したuser
+    profiles_text_match = Profile.text_like(search_params[:text])
+    # profileのoccupationが一致したuser
+    profiles_occupation_match = Profile.occupation_is(search_params[:occupation_id])
+    
+    # nameまたはprofileで取得したuser、かつ、occupationで取得したuser
+    where("name LIKE ?", "%#{search_params[:text]}%")
+    .or(where(id: profiles_text_match.pluck(:user_id)))
+    .where(id: profiles_occupation_match.pluck(:user_id))
   end
 
   # ゲストユーザログイン時に「ゲスト」を検索or作成

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -17,7 +17,7 @@
         </div>
       <% end %>
       <div class="search-cancel">
-        <%= link_to "検索解除", users_path, class:"search-cancel-btn" %>
+        <%= link_to "検索解除", communities_path, class:"search-cancel-btn" %>
       </div> 
     </div>
   </div>

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,8 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # テスト一括実行時のエラー対応 Mysql2::Error: MySQL client is not connected
+  # https://github.com/rails/rails/issues/32794
+  config.active_job.queue_adapter = :inline  
 end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -6,23 +6,30 @@ FactoryBot.define do
     association :user
   end
 
-  factory :community_category2 do
+  factory :community_category2, class:"Community" do
     sequence(:name) { |n| "コミュニティ名_#{n}" }
     text { "コミュニティの紹介文" }
     category_id { 2 }
     association :user
   end
 
-  factory :community_category do
+  factory :community_category3, class:"Community" do
     sequence(:name) { |n| "コミュニティ名_#{n}" }
     text { "コミュニティの紹介文" }
     category_id { 3 }
     association :user
   end
 
-  factory :community_with_other_introduction do
+  factory :community_with_other_name, class:"Community" do
+    name { "community name" }
+    text { "コミュニティの紹介文" }
+    category_id { 1 }
+    association :user
+  end
+
+  factory :community_with_other_introduction, class:"Community" do
     sequence(:name) { |n| "コミュニティ名_#{n}" }
-    text { "community introducion" }
+    text { "community introduction" }
     category_id { 1 }
     association :user
   end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -1,7 +1,28 @@
 FactoryBot.define do
   factory :community do
-    sequence(:name) { |n| "コミュニティタイトル_#{n}" }
-    text { Faker::Quote.matz }
+    sequence(:name) { |n| "コミュニティ名_#{n}" }
+    text { "コミュニティの紹介文" }
+    category_id { 1 }
+    association :user
+  end
+
+  factory :community_category2 do
+    sequence(:name) { |n| "コミュニティ名_#{n}" }
+    text { "コミュニティの紹介文" }
+    category_id { 2 }
+    association :user
+  end
+
+  factory :community_category do
+    sequence(:name) { |n| "コミュニティ名_#{n}" }
+    text { "コミュニティの紹介文" }
+    category_id { 3 }
+    association :user
+  end
+
+  factory :community_with_other_introduction do
+    sequence(:name) { |n| "コミュニティ名_#{n}" }
+    text { "community introducion" }
     category_id { 1 }
     association :user
   end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -6,14 +6,14 @@ FactoryBot.define do
     association :user
   end
 
-  factory :community_category2, class:"Community" do
+  factory :community_with_category2, class:"Community" do
     sequence(:name) { |n| "コミュニティ名_#{n}" }
     text { "コミュニティの紹介文" }
     category_id { 2 }
     association :user
   end
 
-  factory :community_category3, class:"Community" do
+  factory :community_with_category3, class:"Community" do
     sequence(:name) { |n| "コミュニティ名_#{n}" }
     text { "コミュニティの紹介文" }
     category_id { 3 }

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -8,4 +8,44 @@ FactoryBot.define do
       profile.image.attach(io: File.open("public/images/test_image.png"), filename: "test_image.png")
     end
   end
+
+  factory :profile_with_occupation1, class:"Profile" do
+    occupation_id { 1 }
+    text { "プロフィールのテキスト" }
+    association :user
+
+    after(:build) do |profile|
+      profile.image.attach(io: File.open("public/images/test_image.png"), filename: "test_image.png")
+    end
+  end
+
+  factory :profile_with_occupation2, class:"Profile" do
+    occupation_id { 2 }
+    text { "プロフィールのテキスト" }
+    association :user
+
+    after(:build) do |profile|
+      profile.image.attach(io: File.open("public/images/test_image.png"), filename: "test_image.png")
+    end
+  end
+
+  factory :profile_with_occupation3, class:"Profile" do
+    occupation_id { 3 }
+    text { "プロフィールのテキスト" }
+    association :user
+
+    after(:build) do |profile|
+      profile.image.attach(io: File.open("public/images/test_image.png"), filename: "test_image.png")
+    end
+  end
+
+  factory :profile_with_other_introduction, class:"Profile" do
+    occupation_id { 1 }
+    text { "introduction" }
+    association :user
+
+    after(:build) do |profile|
+      profile.image.attach(io: File.open("public/images/test_image.png"), filename: "test_image.png")
+    end
+  end  
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,4 +5,18 @@ FactoryBot.define do
     state { 0 }
     association :user
   end
+
+  factory :completed_task, class:"Task" do
+    sequence(:title) { |n| "taskのタイトル_#{n}" }
+    sequence(:text) { Faker::Quote.matz }
+    state { 1 }
+    association :user
+  end
+
+  factory :not_completed_task, class:"Task" do
+    sequence(:title) { |n| "taskのタイトル_#{n}" }
+    sequence(:text) { Faker::Quote.matz }
+    state { 0 }
+    association :user
+  end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,35 +1,111 @@
 require 'rails_helper'
 
-RSpec.describe Community, type: :model do
-  before do
-    @community = build(:community)
+RSpec.describe Community, type: :model do  
+  describe "communityの登録" do
+    before do
+      @community = build(:community)
+    end
+
+    context "communityを保存できる場合" do
+      it "name、text、categoryが正しく入力されていれば登録できる" do
+        expect(@community).to be_valid
+      end
+      it "categoryがなくても保存できる" do
+        @community.category_id = nil
+        expect(@community).to be_valid
+      end
+    end
+  
+    context "communityを保存できない場合" do
+      it "nameが無いと保存できない" do
+        @community.name = nil
+        @community.valid?
+        expect(@community.errors[:name]).to include("を入力してください")
+      end
+      it "textが無いと保存できない" do
+        @community.text = nil
+        @community.valid?
+        expect(@community.errors[:text]).to include("を入力してください")
+      end
+      it "userが紐付いていないと保存できない" do
+        @community.user = nil
+        @community.valid?
+        expect(@community.errors[:user]).to include("を入力してください")
+      end
+    end
   end
 
-  context "communityを保存できる場合" do
-    it "name、text、categoryが正しく入力されていれば登録できる" do
-      expect(@community).to be_valid
+  describe "communityの検索" do
+    before do
+      @community = create(:community)
+      @community_category2 = create(:community_category2)
+      @community_category3 = create(:community_category3)
+      @community_with_other_name = create(:community_with_other_name)
+      @community_with_other_introduction = create(:community_with_other_introduction)
     end
-    it "categoryがなくても保存できる" do
-      @community.category_id = nil
-      expect(@community).to be_valid
-    end
-  end
 
-  context "communityを保存できない場合" do
-    it "nameが無いと保存できない" do
-      @community.name = nil
-      @community.valid?
-      expect(@community.errors[:name]).to include("を入力してください")
+    # scope :text_like, :text_like
+    describe "文字列に一致するcommunityを検索する" do
+      context "一致するデータが見つかるとき" do
+        it "検索文字列に一致する名前を持つcommunityを返すこと" do
+          expect(Community.text_like("name")).to include(@community_with_other_name)
+        end
+        it "検索文字列に一致する紹介文を持つcommunityを返すこと" do
+          expect(Community.text_like("introduction")).to include(@community_with_other_introduction)
+        end
+      end
+      context "一致するデータが1件も見つからないとき" do
+        it "検索文字列に一致する名前が含まれていなければ、空のコレクションを返すこと" do
+          expect(Community.text_like("Apple")).to be_empty
+        end
+        it "検索文字列に一致する紹介文が含まれていなければ、空のコレクションを返すこと" do
+          expect(Community.text_like("iPhone")).to be_empty
+        end
+      end
     end
-    it "textが無いと保存できない" do
-      @community.text = nil
-      @community.valid?
-      expect(@community.errors[:text]).to include("を入力してください")
+
+    # scope :category_is
+    describe "カテゴリーに一致するcommunityを検索する" do
+      context "一致するデータが見つかるとき" do
+        it "検索カテゴリーが一致するcommunityを返すこと" do
+          expect(Community.category_is(1)).to include(@community, @community_with_other_introduction)
+        end
+      end
+
+      context "一致するデータが1件も見つからないとき" do
+        it "空のコレクションを返すこと" do
+          expect(Community.category_is(99)).to be_empty
+        end
+      end
     end
-    it "userが紐付いていないと保存できない" do
-      @community.user = nil
-      @community.valid?
-      expect(@community.errors[:user]).to include("を入力してください")
+
+    # scope :search
+    describe "文字列とカテゴリーに一致するcommunityを検索する" do
+      context "一致するデータが見つかるとき" do
+        it "検索文字列(名前)と検索カテゴリーが一致するcommunityを返すこと" do
+          search_params = { text: "name", category_id: 1 }
+          expect(Community.search(search_params)).to include(@community_with_other_name)
+        end
+        it "検索文字列(紹介文)と検索カテゴリーが一致するcommunityを返すこと" do
+          search_params = { text: "introduction", category_id: 1 }
+          expect(Community.search(search_params)).to include(@community_with_other_introduction)
+        end
+      end
+
+      context "一致するデータが1件も見つからないとき" do
+        it "名前が一致しなければ空のコレクションを返すこと" do
+          search_params = { text: "Apple" }
+          expect(Community.search(search_params)).to be_empty
+        end
+        it "紹介文が一致しなければ空のコレクションを返すこと" do
+          search_params = { text: "iPhone" }
+          expect(Community.search(search_params)).to be_empty
+        end
+        it "カテゴリーが一致しなければ空のコレクションを返すこと" do
+          search_params = { category_id: 99 }
+          expect(Community.search(search_params)).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Community, type: :model do
     end
   end
 
+  # 検索機能
   describe "communityの検索" do
     before do
       @community = create(:community)
@@ -44,7 +45,7 @@ RSpec.describe Community, type: :model do
       @community_with_other_introduction = create(:community_with_other_introduction)
     end
 
-    # scope :text_like, :text_like
+    # scope :text_like
     describe "文字列に一致するcommunityを検索する" do
       context "一致するデータが見つかるとき" do
         it "検索文字列に一致する名前を持つcommunityを返すこと" do
@@ -105,6 +106,30 @@ RSpec.describe Community, type: :model do
           search_params = { category_id: 99 }
           expect(Community.search(search_params)).to be_empty
         end
+      end
+    end
+  end
+
+  # joined_users
+  describe "userが対象のcommunityに所属しているか確認する" do
+    context "userが所属しているとき" do
+      it "所属しているuserを返すこと" do
+        @community = create(:community)
+        @joined_user1 = create(:user)
+        @joined_user2 = create(:user)
+        @not_joined_user = create(:user)
+        # joined_user1, joined_user2参加
+        @community.user_communities.create(user_id: @joined_user1.id)
+        @community.user_communities.create(user_id: @joined_user2.id)  
+
+        expect(@community.joined_users).to include(@joined_user1, @joined_user2)
+      end
+    end
+
+    context "userが1人も所属していないとき" do
+      it "空のコレクションを返すこと" do
+        @community = create(:community)
+        expect(@community.joined_users).to be_empty
       end
     end
   end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Community, type: :model do
   describe "communityの検索" do
     before do
       @community = create(:community)
-      @community_category2 = create(:community_category2)
-      @community_category3 = create(:community_category3)
+      @community_with_category2 = create(:community_with_category2)
+      @community_with_category3 = create(:community_with_category3)
       @community_with_other_name = create(:community_with_other_name)
       @community_with_other_introduction = create(:community_with_other_introduction)
     end
@@ -113,7 +113,7 @@ RSpec.describe Community, type: :model do
   # joined_users
   describe "userが対象のcommunityに所属しているか確認する" do
     context "userが所属しているとき" do
-      it "所属しているuserを返すこと" do
+      before do
         @community = create(:community)
         @joined_user1 = create(:user)
         @joined_user2 = create(:user)
@@ -121,8 +121,14 @@ RSpec.describe Community, type: :model do
         # joined_user1, joined_user2参加
         @community.user_communities.create(user_id: @joined_user1.id)
         @community.user_communities.create(user_id: @joined_user2.id)  
+      end
 
+      it "所属しているuserを返すこと" do
         expect(@community.joined_users).to include(@joined_user1, @joined_user2)
+      end
+
+      it "所属していないuserは返さないこと" do
+        expect(@community.joined_users).to_not include(@not_joined_user)
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -5,29 +5,58 @@ RSpec.describe Profile, type: :model do
     @profile = build(:profile)
   end
 
-  context "プロフィールが保存できる場合" do
-    it "職種、テキスト、画像を入力すると保存できる" do
-      expect(@profile).to be_valid
+  describe "profileの登録" do
+    context "profileが保存できる場合" do
+      it "職種、テキスト、画像を入力すると保存できる" do
+        expect(@profile).to be_valid
+      end
+      it "職種が空でも保存できる" do
+        @profile.occupation_id = nil
+        expect(@profile).to be_valid
+      end
+      it "テキストが空でも保存できる" do
+        @profile.text = nil
+        expect(@profile).to be_valid
+      end
+      it "画像が空でも保存できる" do
+        @profile.image = nil
+        expect(@profile).to be_valid
+      end
     end
-    it "職種が空でも保存できる" do
-      @profile.occupation_id = nil
-      expect(@profile).to be_valid
-    end
-    it "テキストが空でも保存できる" do
-      @profile.text = nil
-      expect(@profile).to be_valid
-    end
-    it "画像が空でも保存できる" do
-      @profile.image = nil
-      expect(@profile).to be_valid
+
+    context "profileが保存できない場合" do
+      it "ユーザが紐付いていないと保存できない" do
+        @profile.user = nil
+        @profile.valid?
+        expect(@profile.errors[:user]).to include("を入力してください")
+      end
     end
   end
 
-  context "プロフィールが保存できない場合" do
-    it "ユーザが紐付いていないと保存できない" do
-      @profile.user = nil
-      @profile.valid?
-      expect(@profile.errors[:user]).to include("を入力してください")
+
+  describe "profileの検索" do
+    context "一致するデータが見つかるとき" do
+      before do
+        @profile_with_occupation1 = create(:profile_with_occupation1)
+        @profile_with_occupation2 = create(:profile_with_occupation2)
+        @profile_with_other_introduction = create(:profile_with_other_introduction)
+      end
+
+      it "選択occupationが一致するprofileを返すこと" do
+        expect(Profile.occupation_is(1)).to include(@profile_with_occupation1, @profile_with_other_introduction)
+      end
+      it "検索文字列が一致する紹介文を持つprofileを返すこと" do
+        expect(Profile.text_like("introduction")).to include(@profile_with_other_introduction)
+      end
+    end
+
+    context "一致するデータが1件も見つからないとき" do
+      it "選択occupationが一致しなければ空のコレクションを返すこと" do
+        expect(Profile.occupation_is(99)).to be_empty
+      end
+      it "検索文字列が一致しなければ空のコレクションを返すこと" do
+        expect(Profile.text_like("イントロダクション")).to be_empty
+      end
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -5,30 +5,79 @@ RSpec.describe Task, type: :model do
     @task = build(:task)
   end
 
-  context "taskを保存できる場合" do
-    it "title、text、stateがあれば保存できる" do
-      expect(@task).to be_valid
+  describe "taskの保存" do
+    context "taskを保存できる場合" do
+      it "title、text、stateがあれば保存できる" do
+        expect(@task).to be_valid
+      end
+      it "textが無くても保存できる" do
+        @task.text = nil
+        expect(@task).to be_valid
+      end
     end
-    it "textが無くても保存できる" do
-      @task.text = nil
-      expect(@task).to be_valid
+    context "taskを保存できない場合" do
+      it "titleが無いと保存できない" do
+        @task.title = nil
+        @task.valid?
+        expect(@task.errors[:title]).to include("を入力してください")
+      end
+      it "stateが無いと保存できない" do
+        @task.state = nil
+        @task.valid?
+        expect(@task.errors[:state]).to include("は一覧にありません")
+      end
+      it "userが紐付いていないと保存できない" do
+        @task.user = nil
+        @task.valid?
+        expect(@task.errors[:user]).to include("を入力してください")
+      end
     end
   end
-  context "taskを保存できない場合" do
-    it "titleが無いと保存できない" do
-      @task.title = nil
-      @task.valid?
-      expect(@task.errors[:title]).to include("を入力してください")
+
+  describe "特定のuserのtaskを取得" do
+    before do
+      @target_user = create(:user)
+      @target_user_task1 = Task.create(user_id: @target_user.id, title:"タスクタイトル1", state: 0)
+      @target_user_task2 = Task.create(user_id: @target_user.id, title:"タスクタイトル2", state: 0)
+      @not_target_user = create(:user)
     end
-    it "stateが無いと保存できない" do
-      @task.state = nil
-      @task.valid?
-      expect(@task.errors[:state]).to include("は一覧にありません")
+
+    context "一致するデータが見つかるとき" do
+      it "検索対象にしたuserが投稿したtaskを返す" do
+        expect(Task.user_is(@target_user.id)).to include(@target_user_task1, @target_user_task2)
+      end
     end
-    it "userが紐付いていないと保存できない" do
-      @task.user = nil
-      @task.valid?
-      expect(@task.errors[:user]).to include("を入力してください")
+    context "一致するデータが1件も見つからないとき" do
+      it "空のコレクションを返す" do
+        expect(Task.user_is(@not_target_user.id)).to be_empty
+      end
+    end
+  end
+
+  describe "状態を指定してtaskを検索" do
+    context "一致するデータが見つかるとき" do
+      before do
+        @completed_task1 = create(:completed_task)
+        @completed_task2 = create(:completed_task)
+        @not_completed_task1 = create(:not_completed_task)
+        @not_completed_task2 = create(:not_completed_task)
+      end
+
+      it "完了状態のtaskを返す" do
+        expect(Task.completed).to include(@completed_task1, @completed_task2)
+      end
+      it "未完了状態のtaskを返す" do
+        expect(Task.not_completed).to include(@not_completed_task1, @not_completed_task2)
+      end
+    end
+
+    context "一致するデータが1件も見つからないとき" do
+      it "完了状態のtaskがなければ、空のコレクションを返す" do
+        expect(Task.completed).to be_empty
+      end
+      it "未完了状態のtaskがなければ、空のコレクションを返す" do
+        expect(Task.not_completed).to be_empty
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe "新規登録のバリデーション" do
+  describe "userの登録" do
     before do
       @user = build(:user)
     end
@@ -58,6 +58,148 @@ RSpec.describe User, type: :model do
       expect(@user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
     it "パスワード(確認)がパスワードと異なっていると保存できない" do
+    end
+  end
+
+  describe "フォロー済みかどうか判定する" do
+    before do
+      @user_following = create(:user)
+      @user_followed_by_user_following = create(:user)
+      @user_not_followed_by = create(:user)
+      Relationship.create(following_id: @user_following.id, follower_id: @user_followed_by_user_following.id)
+    end
+    
+    context "フォロー済みのとき" do
+      it "trueを返す" do
+        expect(@user_followed_by_user_following.follow?(@user_following)).to be true
+      end
+    end
+    context "フォローしていないとき" do
+      it "falseを返す" do
+        expect(@user_not_followed_by.follow?(@user_following)).to be false
+      end
+    end
+  end
+
+  describe "taskにいいねをしているか判定する" do
+    before do
+      @user = create(:user)
+      @task_liked = create(:task)
+      @task_not_liked = create(:task)
+      Like.create(user_id: @user.id, task_id: @task_liked.id)
+    end
+
+    context "いいねしているとき" do
+      it "trueを返す" do
+        expect(@user.already_liked?(@task_liked)).to be true
+      end
+    end
+    context "いいねしていないとき" do
+      it "falseを返す" do
+        expect(@user.already_liked?(@task_not_liked)).to be false
+      end
+    end
+  end
+
+  describe "対象のcommunityに参加しているかどうかを判定" do
+    before do
+      @user = create(:user)
+      @community_joined = create(:community)
+      @community_not_joined = create(:community)
+      UserCommunity.create(user_id: @user.id, community_id: @community_joined.id)
+    end
+    
+    context "参加しているとき" do
+      it "trueを返す" do
+        expect(@user.already_joined?(@community_joined)).to be true
+      end
+    end
+    context "参加していないとき" do
+      it "falseを返す" do
+        expect(@user.already_joined?(@community_not_joined)).to be false
+      end
+    end
+  end
+
+  describe "対象のquestionに「知りたい！」しているかどうかを判定" do
+    before do
+      @user = create(:user)
+      @question_me_too = create(:question)
+      @question_not_me_too = create(:question)
+      MeToo.create(user_id: @user.id, question_id: @question_me_too.id)
+    end
+
+    context "知りたい！しているとき" do
+      it "trueを返す" do
+        expect(@user.already_me_too?(@question_me_too)).to be true
+      end
+    end
+    context "知りたい！していないとき" do
+      it "falseを返す" do
+        expect(@user.already_me_too?(@question_not_me_too)).to be false
+      end
+    end
+  end
+
+  describe "対象のquestionに「役に立った！」しているかどうかを判定" do
+    before do
+      @user = create(:user)
+      @question_good = create(:question)
+      @question_not_good = create(:question)
+      Good.create(user_id: @user.id, question_id: @question_good.id)
+    end
+
+    context "役に立った！しているとき" do
+      it "trueを返す" do
+        expect(@user.already_good?(@question_good)).to be true
+      end
+    end
+    context "役に立った！していないとき" do
+      it "falseを返す" do
+        expect(@user.already_good?(@question_not_good)).to be false
+      end
+    end
+  end
+
+  # scope :search
+  # warningあり
+  # (Class level methods will no longer inherit scoping from `search` in Rails 6.1.
+  # To continue using the scoped relation, pass it into the block directly.
+  # To instead access the full set of models, as Rails 6.1 will, use `User.default_scoped`.)
+  describe "文字列とカテゴリーに一致するuserを検索する" do
+    before do
+      password = "abc123"
+      password_confirmation = "abc123"
+      @user_steve = User.create(name: "Steve", email: "steve@steve.com", password: password, password_confirmation: password_confirmation)
+      @profile_steve = Profile.create(occupation_id: 1, text: "Apple", user_id: @user_steve.id)
+      @user_bill = User.create(name: "Bill", email: "bill@bill.com", password: password, password_confirmation: password_confirmation)
+      @profile_bill = Profile.create(occupation_id: 1, text: "Microsoft", user_id: @user_bill.id)
+    end
+    
+    context "一致するデータが見つかるとき" do
+      it "検索文字列が一致するuserを返すこと" do
+        search_params = { text: "Steve" }
+        expect(User.search(search_params)).to include(@user_steve)
+      end
+      it "検索文字列が一致するprofileを持つuserを返すこと" do
+        search_params = { text: "Apple" }
+        expect(User.search(search_params)).to include(@user_steve)
+      end
+      it "検索occupationが一致するprofileを持つuserを返すこと" do
+        search_params = { occupation_id: 1 }
+        expect(User.search(search_params)).to include(@user_steve, @user_bill)
+      end
+      it "検索文字列(name or text)と検索occupationが一致するuserを返すこと" do
+        search_params = { text: "Steve", occupation_id: 1 }
+        expect(User.search(search_params)).to include(@user_steve)
+      end
+    end
+
+    context "一致するデータが1件も見つからないとき" do
+      it "空のコレクションを返すこと" do
+        search_params = { text: "Mask" }
+        expect(User.search(search_params)).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
## What
・モデルに記述したメソッドのテストを作成
・userとcommunityのキーワード検索の範囲にnameを追加
## Why
・アプリの品質を担保するため
## コメント
・userのscope :searchのテストに対して、下記の警告が発生したが、
原因理解、コントローラーの改修が必要になるため保留。
(Class level methods will no longer inherit scoping from `search` in Rails 6.1.
To continue using the scoped relation, pass it into the block directly.
To instead access the full set of models, as Rails 6.1 will, use `User.default_scoped`.)