### PR TITLE
タスクの非同期投稿を実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,12 +16,9 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
-    if @task.save
-      redirect_to user_path(current_user)
-    else
+    unless @task.save
       # 投稿タスク一覧取得
       @tasks = @user.tasks.not_completed.order("created_at DESC")
-
       render "users/show"
     end
   end

--- a/app/views/tasks/_task_form.html.erb
+++ b/app/views/tasks/_task_form.html.erb
@@ -1,13 +1,13 @@
 <div class="task-post-form">
-  <%= form_with model: [user, task], local: true do |f|%>
+  <%= form_with model: [user, task], remote: true, id:"taskForm" do |f|%>
     <%= render 'shared/error_messages', model: f.object %>
     <div class="task-form">
       <%= f.label "タスク", class:"task-label"%>
-      <%= f.text_field :title, placeholder: "なにする？", class:"task-input" %>
+      <%= f.text_field :title, placeholder: "なにする？", class:"task-input", id:"taskTitle" %>
     </div>
     <div class="task-form">
       <%= f.label "内容", class:"task-label"%>
-      <%= f.text_area :text, placeholder: "メモもしとく？", class:"task-input text" %>
+      <%= f.text_area :text, placeholder: "メモもしとく？", class:"task-input text", id:"taskText" %>
     </div>
     <%= f.submit "登録", class:"task-submit btn" %>
   <% end %>

--- a/app/views/tasks/create.js.erb
+++ b/app/views/tasks/create.js.erb
@@ -1,0 +1,7 @@
+document.getElementById('postCards').insertAdjacentHTML("afterbegin", `
+  <div id='task_<%= @task.id %>'>
+    <%= escape_javascript(render "shared/tasks", task: @task) %>
+  </div>  
+  `)
+document.getElementById('taskTitle').value = ""
+document.getElementById('taskText').value = ""

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="user-posts">
     <span class="task-index-comment">タスク一覧</span>
-    <div class="posts-cards">
+    <div class="posts-cards", id="postCards">
       <% @tasks.each do |task| %>
         <div id="task_<%= task.id %>">
           <%= render partial: "shared/tasks", locals: { task: task } %>

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Likes', type: :system do
 
       # タスクを投稿
       @task_title = 'タスクのタイトル'
-      fill_in 'task_title', with: @task_title
+      fill_in 'taskTitle', with: @task_title
       click_on '登録'
       @task = Task.find_by(title: @task_title)
     end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Tasks', type: :system do
     context "タスクを投稿できるとき" do
       it "タイトルを入力すれば、タスクを保存できて、マイページに表示される" do
         task_title = 'タスクのタイトル'
-        fill_in 'task_title', with: task_title
+        fill_in 'taskTitle', with: task_title
         expect {
           click_on '登録'
           expect(page).to have_content task_title
@@ -33,7 +33,7 @@ RSpec.describe 'Tasks', type: :system do
         expect(current_url).to include "/users/#{@user.id}"
 
         task_title = 'タスクのタイトル'
-        fill_in 'task_title', with: task_title
+        fill_in 'taskTitle', with: task_title
         expect {
           click_on '登録'
           expect(page).to have_content task_title
@@ -51,7 +51,7 @@ RSpec.describe 'Tasks', type: :system do
 
     it "完了ボタンをクリックすると、タスクが完了になり、マイページに表示されなくなる" do
       task_title = 'タスクのタイトル'
-      fill_in 'task_title', with: task_title
+      fill_in 'taskTitle', with: task_title
       click_on '登録'
       expect(page).to have_content task_title
       # 完了ボタンを押すと、そのタスクは表示されなくなり、stateカラムがtrueになる
@@ -70,8 +70,9 @@ RSpec.describe 'Tasks', type: :system do
 
       # タスクを投稿
       @task_title = 'タスクのタイトル'
-      fill_in 'task_title', with: @task_title
+      fill_in 'taskTitle', with: @task_title
       click_on '登録'
+      sleep 1
       @task = Task.find_by(title: @task_title)
     end
 
@@ -81,7 +82,7 @@ RSpec.describe 'Tasks', type: :system do
         click_link '編集', href: "/users/#{@user.id}/tasks/#{@task.id}/edit"
         expect(current_url).to include "/tasks/#{@task.id}/edit"
         revised_task_title = '編集後のタイトル'
-        fill_in 'task_title', with: revised_task_title
+        fill_in 'taskTitle', with: revised_task_title
         click_on '登録'
         # マイページに遷移し、投稿したタスクがあることを確認する
         expect(page).to have_content revised_task_title
@@ -93,7 +94,7 @@ RSpec.describe 'Tasks', type: :system do
         # 編集ページへ遷移
         click_link '編集', href: "/users/#{@user.id}/tasks/#{@task.id}/edit"
         expect(current_url).to include "/tasks/#{@task.id}/edit"
-        find('#task_title').set ''
+        find('#taskTitle').set ''
         click_on '登録'
         # 保存されず、編集ページに戻ることを確認する
         expect(current_url).to include "/tasks/#{@task.id}"
@@ -111,13 +112,14 @@ RSpec.describe 'Tasks', type: :system do
 
       # タスクを投稿
       @task_title = 'タスクのタイトル'
-      fill_in 'task_title', with: @task_title
+      fill_in 'taskTitle', with: @task_title
       click_on '登録'
       @task = Task.find_by(title: @task_title)
     end
 
     it "削除ボタンをクリックするとタスクが削除され、マイページに表示されなくなる" do
       # 削除ボタンクリックで、Taskのレコードが1減ることを確認
+      sleep 1
       expect {
         # 削除ボタンをクリック
         find('.delete-btn').click


### PR DESCRIPTION
## Issue
Closes #16 
## 内容
- タスク投稿時にcreate.js.erbを読み込み、タスクカードをレンダリングする
- システムスペックの微修正